### PR TITLE
exportがESModule形式だとVSCode tailwind intelicense がエラーになるのでCommonJS形式に変更

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   theme: {
     extend: {
       colors: {


### PR DESCRIPTION
## 💡 解決する issue / Resolved Issues

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes

VSCodeの拡張機能の[Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss)を使いたいのですが、exportがESModule形式だとエラーになるので、CommonJS形式に変更しました。

## 📸 スクリーンショット / Screenshots
