### PR TITLE
generate時、CSSファイルが抽出されるように変更

### DIFF
--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -23,4 +23,7 @@ export default defineNuxtConfig({
   publicRuntimeConfig: {
     NUXT_KOKURYU_FONT_ID: process.env.NUXT_KOKURYU_FONT_ID,
   },
+  build: {
+    extractCSS: true,
+  },
 })


### PR DESCRIPTION
## 💡 解決する issue / Resolved Issues

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes

初回アクセス時、スタイルが当たっていない画面が一瞬表示されるのを防ぐため、generate時、CSSファイルを抽出されるように変更しました。

## 📸 スクリーンショット / Screenshots

↓こういうのを防ぐためです。

https://user-images.githubusercontent.com/19503423/160288882-905edd97-c287-419f-8d33-b47f1547ba9e.mov


