### PR TITLE
波の位置など、メインビジュアル部分のスタイルを調整

### DIFF
--- a/app/components/TopPageSection.vue
+++ b/app/components/TopPageSection.vue
@@ -1,31 +1,36 @@
 <template>
   <section class="py-7">
-    <div class="px-5">
-      <img
-        class="mx-auto mb-6 lg:mb-9"
-        src="/img/kv_solid_3x.png"
-        :alt="conferenceTitle"
-        width="1178"
-      >
-      <h1 class="mb-2.5 text-2xl font-extrabold text-center text-vue-blue md:text-5xl lg:text-6xl">
-        {{ conferenceTitle }}
-      </h1>
-      <p
-        class="mb-[25px] font-extrabold text-center text-vue-blue md:mb-14 md:text-3xl lg:text-4xl"
-      >
-        {{ eventDate }}
-      </p>
-      <div class="text-center">
-        <TweetButtonField
-          :title-label="tweetLabel"
-          @onClick="tweet"
-        />
+    <div class="relative pb-[18vw] mx-auto max-w-[1920px] md:pb-[15vw] lg:pb-[11vw]">
+      <div class="px-5">
+        <img
+          class="mx-auto mb-[6.23vw] lg:mb-9"
+          src="/img/kv_solid_3x.png"
+          :alt="conferenceTitle"
+          width="1178"
+        >
+        <h1
+          class="mb-[2.6vw] text-[7.01vw] font-extrabold leading-none text-center text-vue-blue lg:mb-2.5 lg:text-[4.0625rem]"
+        >
+          {{ conferenceTitle }}
+        </h1>
+        <p
+          class="mb-[6.49vw] text-[3.9vw] font-extrabold text-center text-vue-blue lg:mb-[3.125rem] lg:text-[2.5rem]"
+        >
+          {{ eventDate }}
+        </p>
+        <div class="text-right md:text-center">
+          <TweetButtonField
+            :title-label="tweetLabel"
+            @onClick="tweet"
+          />
+        </div>
       </div>
+      <img
+        class="absolute bottom-0 left-1/2 -z-10 -translate-x-1/2"
+        :src="waveImageSrc"
+        :alt="conferenceTitle"
+      >
     </div>
-    <img
-      :src="waveImageSrc"
-      :alt="conferenceTitle"
-    >
   </section>
 </template>
 
@@ -41,7 +46,7 @@ const tweet = () => {
 
 // 画面サイズで波の画像の読み込み先を切り替え
 onMounted((): void => {
-  const windowSize =  window.innerWidth
+  const windowSize = window.innerWidth
   if (windowSize <= 770) {
     waveImageSrc.value = '/img/wave_sm.png'
     return

--- a/app/components/forms/customize/TweetButtonField.vue
+++ b/app/components/forms/customize/TweetButtonField.vue
@@ -19,7 +19,7 @@ const handleClick = () => {
 <template>
   <button
     type="submit"
-    class="w-[218px] h-9 text-sm text-center text-vue-blue bg-transparent rounded-4xl border border-vue-blue hover:opacity-80 lg:w-[480px] lg:h-16 lg:text-2xl"
+    class="w-[56.62vw] h-[9.48vw] text-[3.38vw] text-center text-vue-blue bg-transparent rounded-4xl border border-vue-blue hover:opacity-80 md:w-[48.98vw] md:h-[6.43vw] md:text-[2.45vw] lg:w-[26.875rem] lg:h-[3.9375rem] lg:text-[1.5rem]"
     @click="handleClick"
   >
     {{ titleLabel }}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -45,9 +45,9 @@ module.exports = {
       'vertical-20': '0 0, 20px 20px',
     },
     screens: {
-      md: '770px',
-      lg: '980px',
-      '3xl': '1920px',
+      md: '771px',
+      lg: '981px',
+      '3xl': '1921px',
     },
   },
 }


### PR DESCRIPTION
## 💡 解決する issue / Resolved Issues

## 📝 関連する issue / Related Issues

#49 

## ⛏ 変更内容 / Details of Changes

メインビジュアル部分のスタイルを調整しました。
主に以下の修正をしました。
- 波の位置を調整
- 拡大、縮小しても余白やサイズ感がおかしくならないようにfont-sizeやmarginを`vw`で指定
- レスポンシブデザインをモバイルファーストで組みやすいようにブレークポイントを1pxずらした

## 📸 スクリーンショット / Screenshots

### sm

<img width="375" src="https://user-images.githubusercontent.com/19503423/160648163-4ba40727-2ceb-4160-b37b-f651e639072f.png">

### md

<img width="980" src="https://user-images.githubusercontent.com/19503423/160648201-e97629db-dc07-4d8a-ab7f-286ec444a493.png">

### lg

![localhost_3000_ (2)](https://user-images.githubusercontent.com/19503423/160648219-f1c07e0a-c548-4448-9dbc-5919dede2d9a.png)

