### PR TITLE
メインビジュアルのレイアウトを微調整

### DIFF
--- a/app/components/TopAnimation.vue
+++ b/app/components/TopAnimation.vue
@@ -1,33 +1,26 @@
 <template>
-  <section class="mt-[1vw] mb-[5vw] md:h-[calc(120px*3_+_12px*2)] lg:h-[calc(((100vw_-_7.8vw*2_-_12px*8)/9)*3_+_12px*2)] 3xl:h-48">
-    <client-only>
-      <svg
-        class="mx-auto max-w-full h-auto"
-        :width="state.width"
-        :height="state.height"
-        :viewBox="`0 0 ${state.width} ${state.height}`"
-      >
-        <g transform="translate(-6, -6)">
-          <transition-group
-            tag="g"
-            mode="out-in"
-            @leave="transitionLeave"
-            @enter="transitionEnter"
+  <client-only>
+    <svg :viewBox="`0 0 ${state.width} ${state.height}`">
+      <g transform="translate(-6, -6)">
+        <transition-group
+          tag="g"
+          mode="out-in"
+          @leave="transitionLeave"
+          @enter="transitionEnter"
+        >
+          <g
+            v-for="item in itemsFlatten()"
+            :key="item.key"
           >
-            <g
-              v-for="item in itemsFlatten()"
-              :key="item.key"
-            >
-              <component
-                :is="item.type"
-                :parts="item"
-              />
-            </g>
-          </transition-group>
-        </g>
-      </svg>
-    </client-only>
-  </section>
+            <component
+              :is="item.type"
+              :parts="item"
+            />
+          </g>
+        </transition-group>
+      </g>
+    </svg>
+  </client-only>
 </template>
 
 <script lang="ts">
@@ -46,11 +39,11 @@ export default {
     HeadHorizontal,
     HeadSlash,
     HeadTriangle,
-    HeadPhoto
+    HeadPhoto,
   },
   setup() {
     const useAnime = useAnimation()
     return { ...useAnime }
-  }
+  },
 }
 </script>

--- a/app/components/TopPageSection.vue
+++ b/app/components/TopPageSection.vue
@@ -2,7 +2,11 @@
   <section class="pb-7">
     <div class="relative pb-[18vw] mx-auto max-w-[1920px] md:pb-[15vw] lg:pb-[11vw]">
       <div class="px-5">
-        <top-animation />
+        <div
+          class="aspect-[648/384] mx-auto mb-[6.23vw] max-w-[1176px] md:aspect-[780/384] lg:aspect-[1176/384] lg:mb-9"
+        >
+          <top-animation />
+        </div>
         <h1
           class="mb-[2.6vw] text-[7.01vw] font-extrabold leading-none text-center text-vue-blue lg:mb-2.5 lg:text-[4.0625rem]"
         >


### PR DESCRIPTION
## 💡 解決する issue / Resolved Issues

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes

メインビジュアルの周りの余白の調整を行い、Figmaのデザインに近づけました。

## 📸 スクリーンショット / Screenshots

<img width="1044" alt="スクリーンショット 2022-04-21 2 11 25" src="https://user-images.githubusercontent.com/19503423/164286131-99617ac4-cd95-4bf6-ab3c-1904c806a097.png">
<img width="1043" alt="スクリーンショット 2022-04-21 2 11 41" src="https://user-images.githubusercontent.com/19503423/164286157-6934aee7-dede-4876-a1bc-21bc813776f5.png">
<img width="1043" alt="スクリーンショット 2022-04-21 2 12 29" src="https://user-images.githubusercontent.com/19503423/164286162-c3e30134-cb91-483c-af84-81d2d341d39a.png">
<img width="1041" alt="スクリーンショット 2022-04-21 2 12 42" src="https://user-images.githubusercontent.com/19503423/164286185-9f52a88f-3180-4a65-b2e4-999d2b2c7b68.png">

