### PR TITLE
focus時にアイコンの色を変更しないように

### DIFF
--- a/app/components/footer/ContactList.vue
+++ b/app/components/footer/ContactList.vue
@@ -52,7 +52,7 @@ const onMouseLeave = (value: string) => {
       target="_blank"
       rel="noopener"
       @mouseover="onMouseOver(network.value)"
-      @focus="onMouseOver(network.value)"
+      @focus="onMouseLeave(network.value)"
       @mouseout="onMouseLeave(network.value)"
       @blur="onMouseLeave(network.value)"
     >


### PR DESCRIPTION
## 💡 解決する issue / Resolved Issues
https://github.com/vuejs-jp/vuefes-2022/issues/121

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes
v-on 側では hover と focus の両方で svg アイコンの色を変更しているが、CSS 側では hover 時のみボタン背景色を変更しているためこの現象が発生していた。
そのため、focus 時には svg アイコンの色を変更しないよう対応した。

## 📸 スクリーンショット / Screenshots
### フォーカス
![image](https://user-images.githubusercontent.com/10795551/168924127-ec08823a-30f9-4b85-a32a-344fdba83ab4.png)

### 通常
![image](https://user-images.githubusercontent.com/10795551/168924054-fc475b0b-824f-40a3-ae9e-6e996395a2e6.png)

### マウスオーバー
![image](https://user-images.githubusercontent.com/10795551/168924099-72f336c2-c3b2-44c8-88d0-595c82fc3051.png)

