### PR TITLE
Issue 115 sponsor section part 2

### DIFF
--- a/app/components/SponsorsPageSection.vue
+++ b/app/components/SponsorsPageSection.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import {
   sponsorsDescriptionText,
-  sponsorTimeline,
+  previousSponsorsApplicationUrl,
   sponsorsDocumentUrl,
   tweetUrl,
   tweetLink,
@@ -22,31 +22,20 @@ import LinkButtonField from '~/components/forms/LinkButtonField.vue'
           title="Sponsors"
           title-yamato="スポンサー"
         />
-        <p class="mb-10 text-sm leading-7 text-vue-blue lg:mb-20 lg:text-lg lg:leading-8">
+        <p class="mb-10 text-sm leading-7 text-vue-blue lg:text-lg lg:leading-8">
           {{ sponsorsDescriptionText }}
         </p>
-        <div class="mb-10 text-center lg:mb-20">
+        <div class="mb-10 text-center lg:mb-10">
           <LinkButtonField
-            :link="sponsorsDocumentUrl"
-            title-label="スポンサー資料を開く"
+            :link="previousSponsorsApplicationUrl"
+            title-label="申し込みフォームを開く"
             :is-external-link="true"
           />
         </div>
         <p class="mb-5 text-sm leading-7 text-vue-blue lg:mb-10 lg:text-lg lg:leading-8">
-          今回は、台風による Vue Fes Japan 2019
-          の開催中止時に一部費用をご負担いただいた当時のスポンサー各社様に感謝の意を込め、以下のスケジュールで募集を予定しています。
+          5/23（月）～5/29（日）は、<span class="font-bold">Vue Fes Japan 2019 のスポンサー（当時）各社様限定の先行申し込み</span>の受付期間です。該当社以外のお申し込みは無効となりますのでご注意ください。一般申し込みは5/30（月）10:00より開始予定です。
         </p>
-        <ul
-          class="mb-5 ml-5 text-sm leading-7 list-disc text-vue-blue lg:mb-10 lg:text-lg lg:leading-8"
-        >
-          <li
-            v-for="(milestone, index) in sponsorTimeline"
-            :key="index"
-          >
-            {{ milestone }}
-          </li>
-        </ul>
-        <p class="text-sm leading-7 text-vue-blue lg:text-lg lg:leading-8">
+        <p class="mb-10 text-sm leading-7 text-vue-blue lg:text-lg lg:leading-8">
           最新情報は、
           <a
             :href="tweetUrl"
@@ -58,6 +47,13 @@ import LinkButtonField from '~/components/forms/LinkButtonField.vue'
           </a>
           をご確認ください。
         </p>
+        <div class="mb-0 text-center">
+          <LinkButtonField
+            :link="sponsorsDocumentUrl"
+            title-label="スポンサー資料を開く"
+            :is-external-link="true"
+          />
+        </div>
       </div>
     </div>
   </section>

--- a/app/utils/constants.ts
+++ b/app/utils/constants.ts
@@ -35,13 +35,9 @@ export const representative = 'Vue.js 日本ユーザーグループ代表 川�
 export const representativeTwitterID = '@kazu_pon'
 
 export const sponsorsDescriptionText =
-  'Vue.js に関わる人々が集まる Vue Fes Japan Online 2022 をよりよいカンファレンスにするため、スポンサーを募集します。詳しい内容は資料をご参照ください。'
+  'Vue.js に関わる人々が集まる Vue Fes Japan Online 2022 をよりよいカンファレンスにするため、スポンサーを募集します。以下の申し込みフォームボタンよりお申し込みください。'
 
-export const sponsorTimeline = [
-  '5/23（月）10:00～ 先行申し込み開始（ Vue Fes Japan 2019 のスポンサー各社様のみ）',
-  '5/30（月）10:00～ 一般申し込み開始',
-  '7/15（金）23:59 申し込み終了',
-]
+export const previousSponsorsApplicationUrl = 'https://fortee.jp/vuefes-2022/sponsor/form'
 
 export const sponsorsDocumentUrl =
   'https://docs.google.com/presentation/d/1f8hKT_fxOre2ClpbOUaZucesophs4NG391oJ0124Pm4/edit?usp=sharing'


### PR DESCRIPTION
## 💡 解決する issue / Resolved Issues
#115 の2回目のリリースの対応で以前にスポンサー専用の申込みリンクを追加しました。

## ⛏ 変更内容 / Details of Changes
esa にかいてあるものを反映して、slackからのもうしこみurlをついかしました。
確認ですが、fortee のurlのご確認おねがいいたします 🙇🏼‍

## 📸 スクリーンショット / Screenshots
![Screenshot 2022-05-19 at 09-39-06 Vue Fes Japan Online 2022](https://user-images.githubusercontent.com/12609324/169178620-ac61b784-7f07-4784-8947-7fcdf283f39a.png)
![Screenshot 2022-05-19 at 09-38-42 Vue Fes Japan Online 2022](https://user-images.githubusercontent.com/12609324/169178626-c8b13517-0a6a-44fe-9f2f-001a637bea8d.png)
