### PR TITLE
スマホ閲覧時、グッズの上下に余白が空いてしまう不具合を修正

### DIFF
--- a/app/components/StorePageSection.vue
+++ b/app/components/StorePageSection.vue
@@ -43,7 +43,7 @@ import {
                 :alt="`${goods.name}のサンプル画像`"
                 :src="`/store/${goods.image}`"
                 loading="lazy"
-                class="block object-contain mx-auto h-full"
+                class="block object-contain mx-auto max-h-full"
               >
             </div>
             <p class="text-2xl font-bold text-center text-vue-blue">


### PR DESCRIPTION
## 💡 解決する issue / Resolved Issues

## 📝 関連する issue / Related Issues

## ⛏ 変更内容 / Details of Changes

## 📸 スクリーンショット / Screenshots
