### PR TITLE
タイムテーブル表示（最新のスピーカ情報）

### DIFF
--- a/app/components/TimeTableSection.vue
+++ b/app/components/TimeTableSection.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import SectionTitle from '~/components/SectionTitle.vue'
+import LiveIcon from '~/components/timetable/LiveIcon.vue'
 function trackClassByIndex(index:number, isSponsorEvent: boolean) {
   switch (index) {
   case 0:
@@ -20,7 +21,7 @@ const timeslots = [
     isSponsorEvent: false,
     events: [
       {
-        title: '会場',
+        title: '開場',
       },
     ],
   },
@@ -28,6 +29,7 @@ const timeslots = [
     time: '10:00 - 10:10',
     isAllTrackEvent: true,
     isSponsorEvent: false,
+    isLive: true,
     events: [
       {
         title: 'オープニングムービー・挨拶｜Kazupon',
@@ -38,6 +40,7 @@ const timeslots = [
     time: '10:10 - 11:00',
     isAllTrackEvent: true,
     isSponsorEvent: false,
+    isLive: true,
     events: [
       {
         title: 'キーノート｜Evan You',
@@ -67,6 +70,7 @@ const timeslots = [
     time: '11:20 - 12:00',
     isAllTrackEvent: true,
     isSponsorEvent: false,
+    isLive: true,
     events: [
       {
         title: 'Evan Youに聞こう',
@@ -137,13 +141,13 @@ const timeslots = [
     isSponsorEvent: false,
     events: [
       {
-        title: 'メインセッション',
+        title: 'とよへい: 負債まみれのレガシーフロントエンド画面を Vue.js でリプレイスした話',
       },
       {
-        title: 'メインセッション',
+        title: '腹筋ローラーの力を信じろ: 不確実性のある将来に対応するためのデザイン戦略',
       },
       {
-        title: 'メインセッション',
+        title: 'miyaoka: Vue2 Vue3 マイグレーション 令和最新 最強',
       },
     ],
   },
@@ -153,13 +157,16 @@ const timeslots = [
     isSponsorEvent: false,
     events: [
       {
-        title: 'メインセッション',
+        title: `1. oreo:  レガシーなMPAアプリケーションをwebpackからviteに移行する話
+2. ebiryu: provide/injectを用いたローカルな状態管理
+3. 掛水優輝: Nuxt2 + Composition API から Nuxt Bridge へのマイグレーションのすゝめ
+4. 古澤 棟熏: Nuxt Content v2でエンジニアブログを作っている話`,
       },
       {
-        title: 'メインセッション',
+        title: 'やまのく: Vue.js でアクセシブルなコンポーネントをつくるために',
       },
       {
-        title: 'メインセッション',
+        title: '川野邉 賢二: こわくない」Vuetifyで始めるOSSコントリビュート',
       },
     ],
   },
@@ -170,7 +177,7 @@ const timeslots = [
     id="timetable"
     class="py-10 px-5 bg-timetable md:px-10 lg:p-20"
   >
-    <div class="relative justify-center p-20 text-center bg-white md:py-12 xl:px-0">
+    <div class="relative justify-center p-20 text-center bg-white md:py-12 xl:px-2">
       <SectionTitle
         class="mb-10 lg:mb-20"
         title="Time Table"
@@ -178,9 +185,9 @@ const timeslots = [
       />
       <div class="grid grid-cols-1 gap-2.5 mx-auto mb-2.5 md:sticky md:top-0 md:grid-cols-md-timetable xl:grid-cols-timetable xl:max-w-[1260px]">
         <div class="py-7 " />
-        <div class="flex justify-center items-center py-4 px-2 text-lg font-bold text-white bg-track-a lg:text-2xl">メドピアトラック</div>
-        <div class="flex justify-center items-center py-4 px-2 text-lg font-bold text-white bg-track-b lg:text-2xl">FUTUREトラック</div>
-        <div class="flex justify-center items-center py-4 px-2 text-lg font-bold text-white bg-track-c lg:text-2xl">クラウドサイントラック</div>
+        <div class="flex justify-center items-center py-4 px-2 text-lg font-bold text-white bg-track-a lg:text-2xl">メドピア<br class="md:hidden">トラック</div>
+        <div class="flex justify-center items-center py-4 px-2 text-lg font-bold text-white bg-track-b lg:text-2xl">FUTURE<br class="md:hidden">トラック</div>
+        <div class="flex justify-center items-center py-4 px-2 text-lg font-bold text-white bg-track-c lg:text-2xl">クラウドサイン<br class="md:hidden">トラック</div>
       </div>
       <div
         v-for="(timeslot, index) in timeslots"
@@ -192,17 +199,17 @@ const timeslots = [
         </p>
         <template v-if="timeslot.isAllTrackEvent">
           <div class="flex col-span-3 justify-center items-center px-1 mb-10 min-h-[5rem] text-base text-center bg-sponsor/[.03] md:mb-0 lg:text-lg">
-            <h3>{{ timeslot.events[0].title }}<br>{{ timeslot.events[0].subTitle }}</h3>
+            <h3><LiveIcon v-if="timeslot.isLive" /> {{ timeslot.events[0].title }}<br>{{ timeslot.events[0].subTitle }}</h3>
           </div>
         </template>
         <template v-else>
           <div
-            v-for="(tracks, index) in timeslot.events"
-            :key="index"
+            v-for="(tracks, eventIndex) in timeslot.events"
+            :key="eventIndex"
             class="flex justify-center items-center px-1 last:mb-10 min-h-[5rem] text-base md:last:mb-0 lg:text-lg"
             :class="trackClassByIndex(index, timeslot.isSponsorEvent)"
           >
-            <h3>{{ tracks.title }}<br>{{ tracks.subTitle }}</h3>
+            <h3 class="whitespace-pre-wrap"><LiveIcon v-if="timeslot.isLive" /> {{ tracks.title }}<br>{{ tracks.subTitle }}</h3>
           </div>
         </template>
       </div>
@@ -210,43 +217,53 @@ const timeslots = [
         class="grid grid-cols-1 gap-y-2.5 mx-auto mb-2.5 md:grid-cols-md-timetable md:gap-2.5 xl:grid-cols-timetable xl:max-w-[1260px]"
       >
         <p class="col-span-3 row-span-2 py-7 min-h-[5rem] text-lg text-center text-white align-middle bg-timetable-timeslot md:col-span-1 lg:text-2xl">
+          14:20 - 15:05
+        </p>
+        <div class="flex flex-col col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><p>14:20 - 14:40</p><h3>志賀 奎太: 施策を止めるな！Vue2からVue3への移行</h3></div>
+        <div class="flex flex-col col-span-3 row-span-2 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-b md:col-span-1 lg:text-lg"><h3><LiveIcon /> OSSはじめのいっぽ</h3></div>
+        <div class="flex flex-col col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-c md:col-span-1 lg:text-lg"><p>14:20 - 14:40</p><h3>川俣 涼:  JSからTSへ移行したVue.jsプロダクトの型チェックを漸進的に強化する</h3></div>
+        <div class="flex flex-col col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><p>14:45 - 15:05</p><h3>tbashiyy: 十数万レコードに耐えうるVue.jsプロジェクトを実現するためのパフォーマンスチューニング</h3></div>
+        <div class="flex flex-col col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-c md:col-span-1 lg:text-lg"><p>14:45 - 15:05</p><h3>Guillaume Chau</h3></div>
+
+        <p class="col-span-3 row-span-2 py-7 min-h-[5rem] text-lg text-center text-white align-middle bg-timetable-timeslot md:col-span-1 lg:text-2xl">
           15:10 - 15:55
         </p>
-        <div class="flex col-span-3 row-span-2 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><h3>ぬるほどVue<br>コンポーネント</h3></div>
-        <div class="flex flex-col col-span-3 row-span-2 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-b md:col-span-1 lg:text-lg"><p>15:10 - 15:30</p><h3>メインセッション</h3><p class="mt-2.5">15:10 - 15:30</p><h3>メインセッション</h3></div>
-        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-c md:col-span-1 lg:text-lg"><p>15:10 - 15:30</p><h3>メインセッション</h3></div>
-        <div class="flex col-span-3 row-span-5 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-c md:col-span-1 lg:text-lg"><p>15:35 - 17:35</p><h3>ハンズオン</h3></div>
+        <div class="flex col-span-3 row-span-2 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><h3>なるほどVue<br>コンポーネント</h3></div>
+        <div class="flex flex-col col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-b md:col-span-1 lg:text-lg"><p>15:10 - 15:30</p><h3>田中弘治: Nuxt モジュールの作り方を知って 開発した機能を再利用しよう</h3></div>
+        <div class="flex flex-col col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-c md:col-span-1 lg:text-lg"><p>15:10 - 15:30</p><h3>Eduardo San Martin Morote</h3></div>
+        <div class="flex flex-col col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-b md:col-span-1 lg:text-lg"><p>15:10 - 15:30</p><h3>太田 洋介:  eslint-plugin-vueを使用して継続的にVue3移行する</h3></div>
+        <div class="flex flex-col col-span-3 row-span-5 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-c md:col-span-1 lg:text-lg"><p>15:35 - 17:35</p><h3><LiveIcon /> ハンズオン</h3></div>
 
         <p class="col-span-3 py-7 min-h-[5rem] text-lg text-center text-white align-middle bg-timetable-timeslot md:col-span-1 lg:text-2xl">
           16:00 - 16:20
         </p>
-        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><h3>メインセッション</h3></div>
-        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-b md:col-span-1 lg:text-lg"><h3>メインセッション</h3></div>
+        
+        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><h3>watsuyo: 安全に開発効率を上げるための Vue 2.7 移行</h3></div>
+        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base border-t-2 border-track-b md:col-span-1 lg:text-lg -sponsor/[.03]"><h3>Sebastien Chopin</h3></div>
         
         <p class="col-span-3 py-7 min-h-[5rem] text-lg text-center text-white align-middle bg-timetable-timeslot md:col-span-1 lg:text-2xl">
           16:25 - 16:45
         </p>
-        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><h3>メインセッション</h3></div>
-        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base border-t-2 border-track-b md:col-span-1 lg:text-lg -sponsor/[.03]"><h3>メインセッション</h3></div>
+        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><h3>Matias Capeletto</h3></div>
+        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-b md:col-span-1 lg:text-lg"><h3>菅家 大地: NuxtJSによるJamstack構築とNuxt 3でどう変わるのか</h3></div>
         
         <p class="col-span-3 py-7 min-h-[5rem] text-lg text-center text-white align-middle bg-timetable-timeslot md:col-span-1 lg:text-2xl">
           16:50 - 17:10
         </p>
-        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><h3>メインセッション</h3></div>
-        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-b md:col-span-1 lg:text-lg"><h3>メインセッション</h3></div>
+        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><h3>Jessica Sachs</h3></div>
+        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-b md:col-span-1 lg:text-lg"><h3>みゅーとん: デザインシステムを後から導入する前提で作った 変更に強いNuxt3プロジェクトの構成</h3></div>
         
         <p class="col-span-3 py-7 min-h-[5rem] text-lg text-center text-white align-middle bg-timetable-timeslot md:col-span-1 lg:text-2xl">
           17:15 - 17:35
-        </p>
-        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><h3>メインセッション</h3></div>
-        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-b md:col-span-1 lg:text-lg"><h3>メインセッション</h3></div>
-        
+        </p>        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-a md:col-span-1 lg:text-lg"><h3>プログラミングをするパンダ: 社内用共通コンポーネントのビジュアルリグレッションテストにStorybookとChromaticを選択した話</h3></div>
+        <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base bg-sponsor/[.03] border-t-2 border-track-b md:col-span-1 lg:text-lg"><h3>Anthony Fu</h3></div>
+
         <p class="col-span-3 py-7 min-h-[5rem] text-lg text-center text-white align-middle bg-timetable-timeslot md:col-span-1 lg:text-2xl">
           18:00 - 19:00
         </p>
         
         <div class="flex col-span-3 justify-center items-center px-1 min-h-[5rem] text-base text-center bg-sponsor/[.03] lg:text-lg">
-          <h3>Peephole</h3>
+          <h3><LiveIcon /> Peephole</h3>
         </div>
       </div>
     </div>

--- a/app/components/timetable/LiveIcon.vue
+++ b/app/components/timetable/LiveIcon.vue
@@ -1,0 +1,3 @@
+<template>
+  <p class="inline text-red-600">[LIVE]</p>
+</template>


### PR DESCRIPTION
## 💡 解決する issue / Resolved Issues
#144 の初期りりーす

## ⛏ 変更内容 / Details of Changes
タイムテーブルの情報は最新のソースから反映しました。

## 🙏ご相談したい項目
1. [LIVE] のアイコンはデザインにはいっていないけど、あった方がよさそう？
2. 「メインせーション」はプレースホルダーであっていますか？
3. スピーカー名とタイトルは同じ行で違和感ある？（ながすぎる懸念しているので一旦同じ行）
4. LTのセクションやタイトルが長いのは高さは問題ないでしょうか？
5. タイムテーブルからスピーカープロフィルにリンクした方がよさそうでしょうか？

## 📸 スクリーンショット / Screenshots
### small
![timetable-sm2](https://user-images.githubusercontent.com/12609324/187058493-9319c7b0-3fa5-4300-89d3-366c56f251d5.png)

### medium
![timetable-md2](https://user-images.githubusercontent.com/12609324/187058495-60a673fd-5f07-4992-a60c-ca333805b399.png)

### large
![timetable-lg2](https://user-images.githubusercontent.com/12609324/187058497-310ae8e3-b8ab-4eff-a4a0-b10a3777ab46.png)